### PR TITLE
Require a specific interface to update over

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["dns"]
 [dependencies]
 config = { version = "0.9", features = [ "json" ] }
 matches = { version = "0.1" }
+pnet = { version = "0.26" }
 reqwest = { version = "0.10", features = [ "blocking", "json" ] }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ keywords = ["dns"]
 
 [dependencies]
 config = { version = "0.9", features = [ "json" ] }
+ipnetwork = { version = "0.16" }
 matches = { version = "0.1" }
 pnet = { version = "0.26" }
 reqwest = { version = "0.10", features = [ "blocking", "json" ] }

--- a/data/test.toml
+++ b/data/test.toml
@@ -1,8 +1,10 @@
 [demo-example-com]
 host = "demo.example.com"
 key = "demo-secret"
+interface = 'enp3s0'
 
 [demo1-example-com]
 host = "demo1.example.com"
 key = "demo1-secret"
+interface = 'enp3s0'
 

--- a/data/test1.toml
+++ b/data/test1.toml
@@ -1,3 +1,4 @@
 [demo2]
 host = "demo2.example.com"
 key = "demo2-secret"
+interface = "enp3s0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   
   let args = Config::from_args();
   let records = records::parse(&args.source_path)?;
+  for record in records {
+    updater::update_ddns_record(&record,
+                                args.what_if).await?;
+  }
+  
   if args.what_if {
     for (_, dns_record) in records {
       println!("Update A record for {:?}", dns_record.host);

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,22 +18,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   
   let args = Config::from_args();
   let records = records::parse(&args.source_path)?;
-  for record in records {
+  for record in records.values() {
     updater::update_ddns_record(&record,
                                 args.what_if).await?;
-  }
-  
-  if args.what_if {
-    for (_, dns_record) in records {
-      println!("Update A record for {:?}", dns_record.host);
-    }
-  } else {
-    let client = reqwest::Client::new();
-    for (_, dns_record) in records {
-      updater::update_ddns_record(&client,
-                                  &dns_record.host,
-                                  &dns_record.key).await?;
-    }
   }
   Ok(())
 }

--- a/src/records.rs
+++ b/src/records.rs
@@ -7,9 +7,24 @@ use std::fs;
 use std::path::Path;
 
 #[derive(Debug, Deserialize)]
+pub enum RecordType {
+  A,
+  AAAA
+}
+
+impl Default for RecordType {
+  fn default() -> Self {
+    RecordType::A
+  }
+}
+
+#[derive(Debug, Deserialize)]
 pub struct DNSRecord {
   pub host: String,
-  pub key: String
+  pub key: String,
+  pub interface: String,
+  #[serde(default)]
+  pub record_type: RecordType
 }
 
 #[derive(Debug)]
@@ -108,6 +123,7 @@ mod tests {
 [demo]
 host = 'demo.example.org'
 key = 'demo-secret'
+interface = 'enp3s0'
 ";
     let records = parse_slice(toml_string.as_bytes())?;
     assert_eq!(records.len(), 1); 
@@ -127,15 +143,31 @@ host = 'demo.example.org'
   }
 
   #[test]
+  fn parse_ipv6_record() -> Result<(), Error> {
+    let toml_string = r"
+[demo]
+host = 'demo.example.org'
+key = 'demo-secret'
+interface = 'enp3s0'
+record_type = 'AAAA'
+";
+    let records = parse_slice(toml_string.as_bytes())?;
+    matches::assert_matches!(records["demo"].record_type, RecordType::AAAA);
+    Ok(())
+  }
+
+  #[test]
   fn parse_multiple_records() -> Result<(), Error> {
     let toml_string = r"
 [demo]
 host = 'demo1.example.org'
 key = 'demo1-secret'
+interface = 'enp3s0'
 
 [other-demo]
 host = 'demo2.example.org'
 key = 'demo2-secret'
+interface = 'enp3s0'
 ";
     let records = parse_slice(toml_string.as_bytes())?;
     assert_eq!(records.len(), 2);

--- a/src/records.rs
+++ b/src/records.rs
@@ -18,6 +18,15 @@ impl Default for RecordType {
   }
 }
 
+impl std::fmt::Display for RecordType {
+  fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "{}", match self {
+      RecordType::A => { "A" }
+      RecordType::AAAA => { "AAAA" }
+    })
+  }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct DNSRecord {
   pub host: String,

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,28 +1,60 @@
-use reqwest::Client;
 use super::records;
+
+fn get_ip_for_interface_by_record_type(
+  record_type: &records::RecordType,
+  interface: &pnet::datalink::NetworkInterface) -> ipnetwork::IpNetwork {
+  match record_type {
+    records::RecordType::A => {
+      let address = interface.ips.iter().filter(|x| { x.is_ipv4() }).next();
+      match address {
+        Some(x) => { x.clone() }
+        None => { panic!("Supplied interface {} doesn't have an IPv4 address as required.", interface.name) }
+      }
+    }
+    records::RecordType::AAAA => {
+      let address = interface.ips.iter().filter(|x| { x.is_ipv6() }).next();
+      match address {
+        Some(x) => { x.clone() }
+        None => { panic!("Supplied interface {} doesn't have an IPv6 address as required.", interface.name) }
+      }
+    }
+  }
+}
 
 pub async fn update_ddns_record(record: &records::DNSRecord, what_if: bool)
                                 -> Result<(), Box<dyn std::error::Error>> {
-  if (what_if) {
+  if what_if {
     println!("Update {} record for {} via {}.", record.record_type, record.host, record.interface);
     Ok(())
-  }
+  } else {
 
-  // Find the interface for the record
-  let interface = pnet::datalink::interfaces().iter()
-    .filter(|x| x.name == record.interface).next()?;
+    let interfaces = pnet::datalink::interfaces();
+    // Find the interface for the record
+    let interface = match interfaces.iter()
+      .filter(|x| x.name == record.interface).next() {
+        Some(iface) => { iface }
+        None => { panic!("Couldn't find expected interface {}.",
+                         record.interface) }
+      };
 
-  // Make sure the interface is usable 
-  let 
+    // Make sure the interface is usable 
+    let address = get_ip_for_interface_by_record_type(&record.record_type,
+                                                      interface);
   
-  let res = client.post("https://dyn.dns.he.net/nic/update")
-    .form(&[("hostname", hostname), ("password", key)])
-    .send()
-    .await?;
+    // Create the client for this interface.
+    let client = reqwest::Client::builder()
+      .local_address(address.ip())
+      .build()?;
 
-  println!("Request response: {:?}", res.status());
+    let res = client.post("https://dyn.dns.he.net/nic/update")
+      .form(&[("hostname", &record.host), ("password", &record.key)])
+      .send()
+      .await?;
 
-  let res_text = res.text().await?;
-  println!("Request body: {:?}", res_text);
-  Ok(())
+    println!("Request response: {:?}", res.status());
+
+    let res_text = res.text().await?;
+    println!("Request body: {:?}", res_text);
+    Ok(())
+  }
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,7 +1,20 @@
 use reqwest::Client;
+use super::records;
 
-pub async fn update_ddns_record(client: &Client, hostname: &str, key: &str)
+pub async fn update_ddns_record(record: &records::DNSRecord, what_if: bool)
                                 -> Result<(), Box<dyn std::error::Error>> {
+  if (what_if) {
+    println!("Update {} record for {} via {}.", record.record_type, record.host, record.interface);
+    Ok(())
+  }
+
+  // Find the interface for the record
+  let interface = pnet::datalink::interfaces().iter()
+    .filter(|x| x.name == record.interface).next()?;
+
+  // Make sure the interface is usable 
+  let 
+  
   let res = client.post("https://dyn.dns.he.net/nic/update")
     .form(&[("hostname", hostname), ("password", key)])
     .send()


### PR DESCRIPTION
In order to ensure that we're getting an IPv4 address when updating an A record, and an IPv6 address when updating an AAAA record, it's best to just declare what interface you're expecting to use to make the request. If this device is behind another firewall, that address can be an RFC1918 address without an issue. The main point is to just not end up with a mismatch when the request arrives at the server.