### PR TITLE
Check DNS and current address before updating

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ config = { version = "0.9", features = [ "json" ] }
 ipnetwork = { version = "0.16" }
 matches = { version = "0.1" }
 pnet = { version = "0.26" }
-reqwest = { version = "0.10", features = [ "blocking", "json" ] }
+reqwest = { version = "0.11.11", features = [ "json" ] }
 dnsclient = { version="0.1.17" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = { version = "1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ddns-updater"
 version = "1.0.0"
 authors = ["Ben Lewis <1884340+ben-zen@users.noreply.github.com>"]
-edition = "2018"
+edition = "2021"
 license = "MIT"
 keywords = ["dns"]
 
@@ -14,8 +14,9 @@ ipnetwork = { version = "0.16" }
 matches = { version = "0.1" }
 pnet = { version = "0.26" }
 reqwest = { version = "0.10", features = [ "blocking", "json" ] }
+dnsclient = { version="0.1.17" }
 serde = { version = "1.0", features = [ "derive" ] }
 serde_derive = { version = "1.0" }
 structopt = { version = "0.3" }
-tokio = { version = "0.2", features = [ "macros", "rt-threaded" ] }
+tokio = { version = "1", features = [ "full" ] }
 toml = { version = "0.5" }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # ddns-updater #
 
-It updates Hurricane Electric dynamic DNS records, ideally as a service.
+A Hurricane Electric dynamic DNS record updater, designed to be run as a service on Linux, with example SystemD unit files provided.
+
+This implementation has checks to not try to update a record if it's currently the same address; this reduces the traffic to the DDNS service. The default endpoint for this is [ifconfig.me](https://ifconfig.me/ip/), but any service which returns a plaintext body in an HTTP response that only contains the requesting client's IP address will work.
 
 ## Configuration format ##
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ use structopt::StructOpt;
 struct Config {
   #[structopt(parse(from_os_str), long)]
   source_path: PathBuf,
+  #[structopt(default_value="https://ifconfig.me/ip", long)]
+  ip_lookup: String,
   #[structopt(long, short)]
   what_if: bool
 }
@@ -20,6 +22,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
   let records = records::parse(&args.source_path)?;
   for record in records.values() {
     updater::update_ddns_record(&record,
+                                &args.ip_lookup,
                                 args.what_if).await?;
   }
   Ok(())

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -1,4 +1,7 @@
 use super::records;
+use dnsclient::r#async::{DNSClient};
+use dnsclient::UpstreamServer;
+use std::net::{IpAddr};
 
 fn get_ip_for_interface_by_record_type(
   record_type: &records::RecordType,
@@ -36,6 +39,18 @@ pub async fn update_ddns_record(record: &records::DNSRecord, what_if: bool)
         None => { panic!("Couldn't find expected interface {}.",
                          record.interface) }
       };
+    
+    let dns_client = DNSClient::new([UpstreamServer::new(([8, 8, 8, 8], 53))].to_vec());
+
+    // Let's check if there is a record for the address.
+    let current_addresses_opt = match dns_client.query_addrs(&record.host).await {
+      Ok(x) => { Some(x) }
+      Err(x) => {
+        // record the failure
+        println!("Error retrieving current DNS records: {}", x);
+        None
+      }
+    };
 
     // Make sure the interface is usable 
     let address = get_ip_for_interface_by_record_type(&record.record_type,
@@ -45,16 +60,50 @@ pub async fn update_ddns_record(record: &records::DNSRecord, what_if: bool)
     let client = reqwest::Client::builder()
       .local_address(address.ip())
       .build()?;
+    
+    // We want to check what our current public IP address is, too.
+    let ip_lookup_result = client.get("https://api.ipify.org/").send().await?;
+    let ip_lookup = match ip_lookup_result.status().is_success() {
+      true => match ip_lookup_result.text().await?.parse::<IpAddr>() {
+        Ok(x) => { Some(x) }
+        Err(x) => {
+          println!("Error parsing the address: {}", x);
+          None
+        }
+      }
+      false => {
+        println!("Didn't get an address back! Got status {}", ip_lookup_result.status());
+        Option::<IpAddr>::None
+      }
+    };
 
-    let res = client.post("https://dyn.dns.he.net/nic/update")
-      .form(&[("hostname", &record.host), ("password", &record.key)])
-      .send()
-      .await?;
+    let mut run_update = true;
+    
+    // Now we want to check, do we have an address already presented for this domain?
+    if let Some(current_ip) = ip_lookup {
+      if let Some(addresses) = current_addresses_opt {
+        for address in addresses {
+          if address == current_ip {
+            println!("Found the current address, not updating.");
+            run_update = false;
+            break;
+          }
+        }
+      }
+    }
 
-    println!("Request response: {:?}", res.status());
+    if run_update 
+    {
+      let res = client.post("https://dyn.dns.he.net/nic/update")
+        .form(&[("hostname", &record.host), ("password", &record.key)])
+        .send()
+        .await?;
 
-    let res_text = res.text().await?;
-    println!("Request body: {:?}", res_text);
+      println!("Request response: {:?}", res.status());
+
+      let res_text = res.text().await?;
+      println!("Request body: {:?}", res_text);
+    }
     Ok(())
   }
 }


### PR DESCRIPTION
Since we don't want to put more load on HE's DDNS service than necessary, we're going to check our current address first; this change adds a configurable endpoint to use, and defaults to ifconfig.me.